### PR TITLE
Feature stdout buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,6 @@ Toolchain Target: stable-x86_64-unknown-linux-gnu
 - [x] Add testing
 - [x] Benchmarks
 - [ ] Add support for JS/Browser
+- Optimizations
+  + [x] Stdout Buffering
+  + [ ] Reducing consecutive `+` and `-` operators

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -60,25 +60,106 @@ pub(crate) fn dot(f: &mut Function, target: &crate::Target) {
             todo!();
         }
         Target::Wasi => {
-            // Write IO Vector
-            f.instruction(&Instruction::I32Const(0));
+            f.instruction(&Instruction::LocalGet(1));
+
+            // Get byte from tape
             f.instruction(&Instruction::LocalGet(0));
+            f.instruction(&Instruction::I32Load(MemArg {
+                align: 0,
+                memory_index: 0,
+                offset: 0,
+            }));
+
+            // Write byte to buffer
             f.instruction(&Instruction::I32Store(MemArg {
                 align: 0,
                 memory_index: 0,
                 offset: 0,
             }));
+
+            // Increment buffer counter
+            f.instruction(&Instruction::LocalGet(1));
             f.instruction(&Instruction::I32Const(4));
+            f.instruction(&Instruction::I32Add);
+            f.instruction(&Instruction::LocalSet(1));
+
+            // Check if buffer needs to be flushed
+            // Start Block
+            f.instruction(&Instruction::Block(BlockType::Empty));
+            f.instruction(&Instruction::LocalGet(1));
+            f.instruction(&Instruction::LocalGet(2));
+            f.instruction(&Instruction::I32LtS);
+            f.instruction(&Instruction::BrIf(0));
+            // Flush Buffer
+            // Write IO Vector
+            // [ start_pos, total_len ]
+            f.instruction(&Instruction::LocalGet(3)); // I/O Vector start point
+            f.instruction(&Instruction::I32Const(0)); // Buffer starts at 0th bit
+            f.instruction(&Instruction::I32Store(MemArg {
+                align: 0,
+                memory_index: 0,
+                offset: 0,
+            }));
+
+            f.instruction(&Instruction::LocalGet(3));
             f.instruction(&Instruction::I32Const(4));
+            f.instruction(&Instruction::I32Add);
+            f.instruction(&Instruction::LocalGet(1)); // length of filled buffer
             f.instruction(&Instruction::I32Store(MemArg {
                 align: 0,
                 memory_index: 0,
                 offset: 0,
             }));
             f.instruction(&Instruction::I32Const(1)); // FD: Stdout
-            f.instruction(&Instruction::I32Const(0)); // *iovs: 0
+            f.instruction(&Instruction::LocalGet(3)); // *iovs: 0
             f.instruction(&Instruction::I32Const(1)); // iovs_len
-            f.instruction(&Instruction::I32Const(16)); // nbytes written
+            f.instruction(&Instruction::LocalGet(3)); // nbytes writen
+            f.instruction(&Instruction::I32Const(8));
+            f.instruction(&Instruction::I32Add);
+            f.instruction(&Instruction::Call(1)); // Call fd_write
+            f.instruction(&Instruction::Drop);
+            // Reset buffer pointer to start of buffer
+            f.instruction(&Instruction::I32Const(0));
+            f.instruction(&Instruction::LocalSet(1));
+
+            // Block End
+            f.instruction(&Instruction::End);
+        }
+    };
+}
+
+/// Flush I/O Buffer
+pub(crate) fn flush_stdout(f: &mut Function, target: &crate::Target) {
+    match target {
+        Target::Browser => {
+            todo!();
+        }
+        Target::Wasi => {
+            // Write IO Vector
+            // [ start_pos, total_len ]
+            f.instruction(&Instruction::LocalGet(3)); // I/O Vector start point
+            f.instruction(&Instruction::I32Const(0)); // Buffer starts at 0th bit
+            f.instruction(&Instruction::I32Store(MemArg {
+                align: 0,
+                memory_index: 0,
+                offset: 0,
+            }));
+
+            f.instruction(&Instruction::LocalGet(3));
+            f.instruction(&Instruction::I32Const(4));
+            f.instruction(&Instruction::I32Add);
+            f.instruction(&Instruction::LocalGet(1)); // length of filled buffer
+            f.instruction(&Instruction::I32Store(MemArg {
+                align: 0,
+                memory_index: 0,
+                offset: 0,
+            }));
+            f.instruction(&Instruction::I32Const(1)); // FD: Stdout
+            f.instruction(&Instruction::LocalGet(3)); // *iovs: 0
+            f.instruction(&Instruction::I32Const(1)); // iovs_len
+            f.instruction(&Instruction::LocalGet(3)); // nbytes writen
+            f.instruction(&Instruction::I32Const(8));
+            f.instruction(&Instruction::I32Add);
             f.instruction(&Instruction::Call(1)); // Call fd_write
             f.instruction(&Instruction::Drop);
         }
@@ -93,14 +174,16 @@ pub(crate) fn comma(f: &mut Function, target: &crate::Target) {
         }
         Target::Wasi => {
             // Write IO Vector
-            f.instruction(&Instruction::I32Const(0));
+            f.instruction(&Instruction::LocalGet(3)); // I/O Vector start point
             f.instruction(&Instruction::LocalGet(0));
             f.instruction(&Instruction::I32Store(MemArg {
                 align: 0,
                 memory_index: 0,
                 offset: 0,
             }));
+            f.instruction(&Instruction::LocalGet(3));
             f.instruction(&Instruction::I32Const(4));
+            f.instruction(&Instruction::I32Add);
             f.instruction(&Instruction::I32Const(1));
             f.instruction(&Instruction::I32Store(MemArg {
                 align: 0,
@@ -108,9 +191,11 @@ pub(crate) fn comma(f: &mut Function, target: &crate::Target) {
                 offset: 0,
             }));
             f.instruction(&Instruction::I32Const(0)); // FD: Stdin
-            f.instruction(&Instruction::I32Const(0)); // *iovs: 0
+            f.instruction(&Instruction::LocalGet(3)); // *iovs: 0
             f.instruction(&Instruction::I32Const(1)); // iovs_len
-            f.instruction(&Instruction::I32Const(16)); // nbytes written
+            f.instruction(&Instruction::LocalGet(3)); // nbytes writen
+            f.instruction(&Instruction::I32Const(8));
+            f.instruction(&Instruction::I32Add);
             f.instruction(&Instruction::Call(0)); // Call fd_read
             f.instruction(&Instruction::Drop);
         }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -113,18 +113,27 @@ impl Language {
         let mut codes = CodeSection::new();
         // Local Declaration
         // Local 0 : I32 TAPE Pointer
+        // Local 1 : I32 I/O Buffer pointer
+        // Local 2 : I32 I/O Buffer max-size
+        // Local 3 : I32 I/O Vector start
         // ...
-        let locals = vec![(3, ValType::I32)];
+        let locals = vec![(4, ValType::I32)];
         let mut f = Function::new(locals);
 
         // <-- Linear Memory Model -->
         // ---------------------------
-        // | IOV  and Tmp |  TAPE    |
-        // 0-----------1024------4096|
+        // | I/O Buffer | I/O Vectors |  TAPE    |
+        // 0-----------516-----------1024------4096|
         // TODO: Check if memory pointer invalid
         // TODO: Tape expansion
         f.instruction(&Instruction::I32Const(1024));
         f.instruction(&Instruction::LocalSet(0));
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::LocalSet(1));
+        f.instruction(&Instruction::I32Const(1000));
+        f.instruction(&Instruction::LocalSet(2));
+        f.instruction(&Instruction::I32Const(1004));
+        f.instruction(&Instruction::LocalSet(3));
 
         // Symbol matching
         let mut fcount: u32 = 2;
@@ -146,7 +155,10 @@ impl Language {
                 }
             }
         }
-        // Cleanup
+
+        // Flush Stdout
+        compiler::flush_stdout(&mut f, target);
+        // Mark program end
         f.instruction(&Instruction::End);
 
         codes.function(&f);


### PR DESCRIPTION
Reduces the number of write syscalls made by the compiler by adding buffering.
For `benchmarks/code/mandelbrot-titanic.bf` number of write syscalls reduced from `99264` to `589`.

Below is the syscall summary without stdout buffering
```text

% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
100.00    0.022727           0     99264           write
  0.00    0.000000           0        13           read
  0.00    0.000000           0        10           close
  0.00    0.000000           0         1           fstat
  0.00    0.000000           0         1           poll
  0.00    0.000000           0         1           lseek
  0.00    0.000000           0        35           mmap
  0.00    0.000000           0        13           mprotect
  0.00    0.000000           0         6           munmap
  0.00    0.000000           0         3           brk
  0.00    0.000000           0         8           rt_sigaction
  0.00    0.000000           0         4           pread64
  0.00    0.000000           0         1         1 access
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         5           sigaltstack
  0.00    0.000000           0         2         1 arch_prctl
  0.00    0.000000           0         1           sched_getaffinity
  0.00    0.000000           0         1           set_tid_address
  0.00    0.000000           0        10           openat
  0.00    0.000000           0         8           newfstatat
  0.00    0.000000           0         1           set_robust_list
  0.00    0.000000           0         2           prlimit64
  0.00    0.000000           0         2           getrandom
  0.00    0.000000           0         2         1 statx
  0.00    0.000000           0         1           rseq
------ ----------- ----------- --------- --------- ------------------
100.00    0.022727           0     99396         3 total
```

Below is the syscall summary with stdout buffering
```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
100.00    0.000034           0       589           write
  0.00    0.000000           0        13           read
  0.00    0.000000           0        10           close
  0.00    0.000000           0         1           fstat
  0.00    0.000000           0         1           poll
  0.00    0.000000           0         1           lseek
  0.00    0.000000           0        35           mmap
  0.00    0.000000           0        13           mprotect
  0.00    0.000000           0         6           munmap
  0.00    0.000000           0         3           brk
  0.00    0.000000           0         8           rt_sigaction
  0.00    0.000000           0         4           pread64
  0.00    0.000000           0         1         1 access
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         5           sigaltstack
  0.00    0.000000           0         2         1 arch_prctl
  0.00    0.000000           0         1           sched_getaffinity
  0.00    0.000000           0         1           set_tid_address
  0.00    0.000000           0        10           openat
  0.00    0.000000           0         8           newfstatat
  0.00    0.000000           0         1           set_robust_list
  0.00    0.000000           0         2           prlimit64
  0.00    0.000000           0         2           getrandom
  0.00    0.000000           0         2         1 statx
  0.00    0.000000           0         1           rseq
------ ----------- ----------- --------- --------- ------------------
100.00    0.000034           0       721         3 total
```